### PR TITLE
Created MSSidebarControllerAnimatorFactory.

### DIFF
--- a/MSSidebarController/Classes/Events/MSSidebarControllerEventDisplayMenu.h
+++ b/MSSidebarController/Classes/Events/MSSidebarControllerEventDisplayMenu.h
@@ -13,6 +13,6 @@
 + (instancetype)eventWithSidebarController:(MSSidebarController *)sidebarController
                        viewControllerState:(TKState *)vcState
                        displayingMenuState:(TKState *)displayingMenuState
-                                  animator:(id<MSSidebarDisplayMenuAnimator>)animator;
+                           animatorFactory:(id<MSSidebarControllerAnimatorFactory>)animatorFactory;
 
 @end

--- a/MSSidebarController/Classes/Events/MSSidebarControllerEventDisplayMenu.m
+++ b/MSSidebarController/Classes/Events/MSSidebarControllerEventDisplayMenu.m
@@ -13,7 +13,7 @@
 
 @interface MSSidebarControllerEventDisplayMenu ()
 
-@property (nonatomic) id<MSSidebarDisplayMenuAnimator> animator;
+@property (nonatomic) id<MSSidebarControllerAnimatorFactory> animatorFactory;
 
 @end
 
@@ -22,15 +22,15 @@
 + (instancetype)eventWithSidebarController:(MSSidebarController *)sidebarController
                        viewControllerState:(TKState *)vcState
                        displayingMenuState:(TKState *)displayingMenuState
-                                  animator:(id<MSSidebarDisplayMenuAnimator>)animator {
+                           animatorFactory:(id<MSSidebarControllerAnimatorFactory>)animatorFactory {
     NSParameterAssert(vcState);
     NSParameterAssert(displayingMenuState);
-    NSParameterAssert(animator);
+    NSParameterAssert(animatorFactory);
     
     MSSidebarControllerEventDisplayMenu *event = [self eventWithSidebarController:sidebarController
                                                           transitioningFromStates:@[vcState]
                                                                           toState:displayingMenuState];
-    event.animator = animator;
+    event.animatorFactory = animatorFactory;
     
     return event;
 }
@@ -52,12 +52,13 @@
     
     currentViewController.view.userInteractionEnabled = NO;
     
-    [self.animator sidebarController:sidebarController
-           willDismissViewController:currentViewController
-                      andDisplayMenu:menuViewController
-                     completionBlock:^{
-                         [sidebarController fireEvent:MSSidebarControllerEventMenuDisplayed.eventName];
-                     }];
+    [[self.animatorFactory createDisplayMenuAnimatorForSidebarController:sidebarController] sidebarController:sidebarController
+                                                                                    willDismissViewController:currentViewController
+                                                                                               andDisplayMenu:menuViewController
+                                                                                              completionBlock:^
+     {
+         [sidebarController fireEvent:MSSidebarControllerEventMenuDisplayed.eventName];
+     }];
 }
 
 @end

--- a/MSSidebarController/Classes/Events/MSSidebarControllerEventDisplayViewController.h
+++ b/MSSidebarController/Classes/Events/MSSidebarControllerEventDisplayViewController.h
@@ -14,6 +14,6 @@
                                  menuState:(TKState *)menuState
                  hidingViewControllerState:(TKState *)hidingViewControllerState
              displayingViewControllerState:(TKState *)displayingViewControllerState
-                                  animator:(id<MSSidebarDisplayViewControllerAnimator>)animator;
+                           animatorFactory:(id<MSSidebarControllerAnimatorFactory>)animatorFactory;
 
 @end

--- a/MSSidebarController/Classes/Events/MSSidebarControllerEventDisplayViewController.m
+++ b/MSSidebarController/Classes/Events/MSSidebarControllerEventDisplayViewController.m
@@ -15,7 +15,7 @@
 
 @interface MSSidebarControllerEventDisplayViewController ()
 
-@property (nonatomic) id<MSSidebarDisplayViewControllerAnimator> animator;
+@property (nonatomic) id<MSSidebarControllerAnimatorFactory> animatorFactory;
 
 @end
 
@@ -25,17 +25,17 @@
                                  menuState:(TKState *)menuState
                  hidingViewControllerState:(TKState *)hidingViewControllerState
              displayingViewControllerState:(TKState *)displayingViewControllerState
-                                  animator:(id<MSSidebarDisplayViewControllerAnimator>)animator {
+                           animatorFactory:(id<MSSidebarControllerAnimatorFactory>)animatorFactory {
     NSParameterAssert(menuState);
     NSParameterAssert(hidingViewControllerState);
     NSParameterAssert(displayingViewControllerState);
-    NSParameterAssert(animator);
+    NSParameterAssert(animatorFactory);
     
     MSSidebarControllerEventDisplayViewController *event = [self eventWithSidebarController:sidebarController
                                                                     transitioningFromStates:@[menuState, hidingViewControllerState]
                                                                                     toState:displayingViewControllerState];
     
-    event.animator = animator;
+    event.animatorFactory = animatorFactory;
     
     return event;
 }
@@ -53,13 +53,14 @@
     
     [sidebarController.menuViewController willMoveToParentViewController:nil];
     
-    [self.animator sidebarController:sidebarController
-           willDisplayViewController:vc
-                     completionBlock:^{
-                         [sidebarController fireEvent:MSSidebarControllerEventViewControllerDisplayed.eventName
-                                   withViewController:vc
-                                  viewControllerIsNew:transition.viewControllerIsNew];
-                     }];
+    [[self.animatorFactory createDisplayViewControllerAnimatorForSidebarController:sidebarController] sidebarController:sidebarController
+                                                                                              willDisplayViewController:vc
+                                                                                                        completionBlock:^
+     {
+         [sidebarController fireEvent:MSSidebarControllerEventViewControllerDisplayed.eventName
+                   withViewController:vc
+                  viewControllerIsNew:transition.viewControllerIsNew];
+     }];
 }
 
 @end

--- a/MSSidebarController/Classes/Events/MSSidebarControllerEventHideViewController.h
+++ b/MSSidebarController/Classes/Events/MSSidebarControllerEventHideViewController.h
@@ -13,6 +13,6 @@
 + (instancetype)eventWithSidebarController:(MSSidebarController *)sidebarController
                                  menuState:(TKState *)menuState
                  hidingViewControllerState:(TKState *)hidingVCState
-                                  animator:(id<MSSidebarHideViewControllerAnimator>)animator;
+                           animatorFactory:(id<MSSidebarControllerAnimatorFactory>)animatorFactory;
 
 @end

--- a/MSSidebarController/Classes/Events/MSSidebarControllerEventHideViewController.m
+++ b/MSSidebarController/Classes/Events/MSSidebarControllerEventHideViewController.m
@@ -13,7 +13,7 @@
 
 @interface MSSidebarControllerEventHideViewController ()
 
-@property (nonatomic) id<MSSidebarHideViewControllerAnimator> animator;
+@property (nonatomic) id<MSSidebarControllerAnimatorFactory> animatorFactory;
 
 @end
 
@@ -22,15 +22,15 @@
 + (instancetype)eventWithSidebarController:(MSSidebarController *)sidebarController
                                  menuState:(TKState *)menuState
                  hidingViewControllerState:(TKState *)hidingVCState
-                                  animator:(id<MSSidebarHideViewControllerAnimator>)animator {
+                           animatorFactory:(id<MSSidebarControllerAnimatorFactory>)animatorFactory {
     NSParameterAssert(menuState);
     NSParameterAssert(hidingVCState);
-    NSParameterAssert(animator);
+    NSParameterAssert(animatorFactory);
     
     MSSidebarControllerEventHideViewController *event = [self eventWithSidebarController:sidebarController
                                                                  transitioningFromStates:@[menuState]
                                                                                  toState:hidingVCState];
-    event.animator = animator;
+    event.animatorFactory = animatorFactory;
     
     return event;
 }
@@ -51,10 +51,10 @@
     UIViewController *currentVC = sidebarController.currentViewController,
                      *newVC = transition.userInfoViewController;
     
-    [self.animator sidebarController:sidebarController
-              willHideViewController:currentVC
-             toShowNewViewController:newVC
-                     completionBlock:^
+    [[self.animatorFactory createHideViewControllerAnimatorForSidebarController:sidebarController] sidebarController:sidebarController
+                                                                                              willHideViewController:currentVC
+                                                                                             toShowNewViewController:newVC
+                                                                                                     completionBlock:^
      {
          [currentVC.view removeFromSuperview];
          [currentVC removeFromParentViewController];

--- a/MSSidebarController/Classes/Public/MSSidebarAnimations.h
+++ b/MSSidebarController/Classes/Public/MSSidebarAnimations.h
@@ -33,3 +33,11 @@ willDismissViewController:(UIViewController *)currentViewController
           completionBlock:(void (^)(void))completionBlock;
 
 @end
+
+@protocol MSSidebarControllerAnimatorFactory <NSObject>
+
+- (id<MSSidebarDisplayViewControllerAnimator>)createDisplayViewControllerAnimatorForSidebarController:(MSSidebarController *)sidebarController;
+- (id<MSSidebarDisplayMenuAnimator>)createDisplayMenuAnimatorForSidebarController:(MSSidebarController *)sidebarController;
+- (id<MSSidebarHideViewControllerAnimator>)createHideViewControllerAnimatorForSidebarController:(MSSidebarController *)sidebarController;
+
+@end

--- a/MSSidebarController/Classes/Public/MSSidebarController.h
+++ b/MSSidebarController/Classes/Public/MSSidebarController.h
@@ -15,9 +15,7 @@
  */
 - (instancetype)initWithMenuViewController:(UIViewController *)menuVC
                       activeViewController:(UIViewController *)activeVC
-             displayViewControllerAnimator:(id<MSSidebarDisplayViewControllerAnimator>)displayVCAnimator
-                       displayMenuAnimator:(id<MSSidebarDisplayMenuAnimator>)displayMenuAnimator
-                hideViewControllerAnimator:(id<MSSidebarHideViewControllerAnimator>)hideVCAnimator;
+                           animatorFactory:(id<MSSidebarControllerAnimatorFactory>)animatorFactory;
 
 - (void)showMenu;
 - (void)restoreLastViewController;

--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ You must instantiate the [controller](MSSidebarController/Classes/Public/MSSideb
 ```objc
 [[MSSidebarController alloc] initWithMenuViewController:menuVC
                                    activeViewController:activeVC
-                          displayViewControllerAnimator:displayViewControllerAnimator
-                                    displayMenuAnimator:displayMenuAnimator
-                             hideViewControllerAnimator:hideViewControllerAnimator];
+                                        animatorFactory:animatorFactory];
 ```
 
 You must also implement all three animation protocols:


### PR DESCRIPTION
Instead of requiring already instantiated animators, NSSidebarController now 
uses the injected factory to create disposable animators. The implementation
for these can now have state, as that will be thrown away for the next
animation.
